### PR TITLE
Fix Modbus Point Type Selections

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,6 @@ github.com/NubeIO/lib-utils-go v0.0.1/go.mod h1:KYE8yYY3KhdN/+s/QfdLFLqkJsM44ftL
 github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7 h1:QKgcOjDkVujyAXWK+OysVFnQKzpZx335vGPG95UNXuI=
 github.com/NubeIO/nubeio-rubix-lib-helpers-go v0.2.7/go.mod h1:oLI6n9wuko0KIEzrLc8saOquiQvtMUUBrUjXf0TLDVQ=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.0.4/go.mod h1:A1BPuc3UpE1EF3ugdf+8QIIKTT8s3eK+pfUcheJX2JM=
-github.com/NubeIO/nubeio-rubix-lib-models-go v1.13.0/go.mod h1:tTdOPP0bMUe6FR/zYu3B/TXkG7j1z8Pz+ViNh9dTNl4=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.14.0 h1:5qD2BXAIr8nRaWREO3Hm/0I6HFZyRZAnh+3fmTubdGU=
 github.com/NubeIO/nubeio-rubix-lib-models-go v1.14.0/go.mod h1:tTdOPP0bMUe6FR/zYu3B/TXkG7j1z8Pz+ViNh9dTNl4=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/schema/modbus.go
+++ b/schema/modbus.go
@@ -12,8 +12,8 @@ type DataType struct {
 type ObjectEncoding struct {
 	Type     string   `json:"type" default:"string"`
 	Title    string   `json:"title" default:"Object Encoding (Endianness)"`
-	Options  []string `json:"enum" default:"[\"beb_lew\",\"beb_bew\",\"leb_lew\",\"leb_bew\"]"`
-	EnumName []string `json:"enumNames" default:"[\"Big byte order, Little word order (1032)\",\"Big byte order, Big word order (3210)\",\"Little byte order, Big word order (0123)\",\"Little byte order, Little word order (2301)\"]"`
+	Options  []string `json:"enum" default:"[\"beb_bew\",\"leb_bew\",\"beb_lew\",\"leb_lew\",]"`
+	EnumName []string `json:"enumNames" default:"[\"Standard/Network Order (ABCD)\",\"Byte Swap (BADC)\",\"Word Swap (CDAB)\",\"Byte Swap + Word Swap (DCBA)\"]"`
 	Default  string   `json:"default" default:"beb_lew"`
 	ReadOnly bool     `json:"readOnly" default:"false"`
 }
@@ -21,8 +21,8 @@ type ObjectEncoding struct {
 type ObjectTypeModbus struct {
 	Type     string   `json:"type" default:"string"`
 	Title    string   `json:"title" default:"Object Type"`
-	Options  []string `json:"enum" default:"[\"coil\",\"discrete_input\",\"input_register\",\"holding_register\",\"read_coil\",\"write_coil\",\"read_discrete_input\",\"read_register\",\"read_holding\",\"write_holding\"]"`
-	EnumName []string `json:"enumNames" default:"[\"Coil\",\"Discrete Input\",\"Input Register\",\"Holding Register\",\"Read Coil\",\"Write Coil\",\"Read Discrete Input\",\"Read Input Register\",\"Read Holding Register\",\"Write Holding Register\"]"`
+	Options  []string `json:"enum" default:"[\"coil\",\"discrete_input\",\"input_register\",\"holding_register\"]"`
+	EnumName []string `json:"enumNames" default:"[\"Coil\",\"Discrete Input\",\"Input Register\",\"Holding Register\"]"`
 	Default  string   `json:"default" default:"coil"`
 	ReadOnly bool     `json:"readOnly" default:"false"`
 }


### PR DESCRIPTION
Refs:

- https://store.chipkin.com/articles/how-real-floating-point-and-32-bit-data-is-encoded-in-modbus-rtu-messages
- https://en.wikipedia.org/wiki/Endianness

@Shiny380 Any reason that we made our IO Modules use `Word Swap (Big-Endian-Byte, Low-Endian-Word) [CDAB]`? Just curious. 